### PR TITLE
do not pull in tensorboard's keras callback

### DIFF
--- a/clu/metric_writers/tf/summary_writer.py
+++ b/clu/metric_writers/tf/summary_writer.py
@@ -27,7 +27,7 @@ from clu.internal import utils
 from clu.metric_writers import interface
 import tensorflow as tf
 
-from tensorboard.plugins.hparams import api as hparams_api
+from tensorboard.plugins.hparams import summary_v2
 
 
 Array = interface.Array
@@ -95,7 +95,7 @@ class SummaryWriter(interface.MetricWriter):
 
   def write_hparams(self, hparams: Mapping[str, Any]):
     with self._summary_writer.as_default():
-      hparams_api.hparams(dict(utils.flatten_dict(hparams)))
+      summary_v2.hparams(dict(utils.flatten_dict(hparams)))
 
   def flush(self):
     self._summary_writer.flush()


### PR DESCRIPTION
i am moving some of my models to keras3 and using jax backend for training. i am on a slightly older tensorboard (2.12) so when it pulls in keras callback through `from tensorboard.plugins.hparams import api` it tries to pull in keras2 since `api` also import keras callback in tensorboard repo.

this pr basically adjusted import to avoid accidentally pulling in keras in clu.