### PR TITLE
Fix incorrect stats for bf16 params in parameter_overview

### DIFF
--- a/clu/parameter_overview.py
+++ b/clu/parameter_overview.py
@@ -52,12 +52,21 @@ class _ParamRowWithStatsAndSharding(_ParamRowWithStats):
   sharding: tuple[int | None, ...] | str
 
 
+def _upcast(x):
+  """Upcast low-precision floats to float32 for numerically stable stats."""
+  if hasattr(x, "dtype") and jnp.issubdtype(x.dtype, jnp.floating) and x.dtype != jnp.float32:
+    return x.astype(jnp.float32)
+  return x
+
+
 @jax.jit
 def _mean_std_jit(x):
+  x = jax.tree_util.tree_map(_upcast, x)
   return jax.tree_util.tree_map(jnp.mean, x), jax.tree_util.tree_map(jnp.std, x)
 
 
 def _mean_std(x):
+  x = jax.tree_util.tree_map(_upcast, x)
   mean = jax.tree_util.tree_map(lambda x: x.mean(), x)
   std = jax.tree_util.tree_map(lambda x: x.std(), x)
   return mean, std


### PR DESCRIPTION
For bfloat16 parameters, accumulating over large tensors produces numerically incorrect results due to bf16 limited precision (~3 significant digits).

A (768,) LayerNorm `scale` initialized to all 1.0 in bf16 is reported as mean=0.334 std=0.408 instead of mean=1.0 std=0.0. A (768, 768) weight matrix shows ~20x underestimated std.

Upcasts arrays to float32 to compute stats. Reported dtype in the overview table remains the original dtype e.g. bfloat16.